### PR TITLE
Add dynamic feature management

### DIFF
--- a/rspamd-config/lua.local.d/whiteblacklist.lua
+++ b/rspamd-config/lua.local.d/whiteblacklist.lua
@@ -4,73 +4,106 @@ local settings = {
     whitelist_users_key = 'tg:whitelist:users',
     blacklist_users_key = 'tg:blacklist:users',
     whitelist_words_key = 'tg:whitelist:words',
-    blacklist_words_key = 'tg:blacklist:words'
+    blacklist_words_key = 'tg:blacklist:words',
+    features_key = 'tg:enabled_features'
 }
+
+local function if_feature_enabled(task, chat_id, feature, cb)
+    local chat_key = 'tg:chats:' .. chat_id
+    local field = 'feat:' .. feature
+    rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+        cmd='HGET', args={chat_key, field}, callback=function(err, data)
+            if err then return end
+            if data == '1' then
+                cb()
+            elseif data == '0' then
+                return
+            else
+                rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+                    cmd='SISMEMBER', args={settings.features_key, feature}, callback=function(e,d)
+                        if e then return end
+                        if d == 1 or d == true then cb() end
+                    end})
+            end
+        end})
+end
 
 rspamd_config:register_symbol('WHITELIST_USER', 1.0, function(task)
     local user_id = tostring(task:get_header('X-Telegram-User', true) or "")
+    local chat_id = tostring(task:get_header('X-Telegram-Chat', true) or "")
     if user_id == "" then return false end
     local user_key = settings.user_prefix .. user_id
-    local function whitelist_cb (err, data)
-        if err or not data then return end
-        if data then
-            task:insert_result('WHITELIST_USER', 1.0)
+    if_feature_enabled(task, chat_id, 'whitelist', function()
+        local function whitelist_cb (err, data)
+            if err or not data then return end
+            if data then
+                task:insert_result('WHITELIST_USER', 1.0)
+            end
         end
-    end
-    rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
-                               cmd='SISMEMBER', args={settings.whitelist_users_key, user_key}, callback=whitelist_cb})
+        rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+                                   cmd='SISMEMBER', args={settings.whitelist_users_key, user_key}, callback=whitelist_cb})
+    end)
 end)
 
 rspamd_config:register_symbol('BLACKLIST_USER', 1.0, function(task)
     local user_id = tostring(task:get_header('X-Telegram-User', true) or "")
+    local chat_id = tostring(task:get_header('X-Telegram-Chat', true) or "")
     if user_id == "" then return false end
     local user_key = settings.user_prefix .. user_id
-    local function whitelist_cb (err, data)
-        if err or not data then return end
-        if data then
-            task:insert_result('BLACKLIST_USER', 1.0)
+    if_feature_enabled(task, chat_id, 'blacklist', function()
+        local function whitelist_cb (err, data)
+            if err or not data then return end
+            if data then
+                task:insert_result('BLACKLIST_USER', 1.0)
+            end
         end
-    end
-    rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
-                               cmd='SISMEMBER', args={settings.blacklist_users_key, user_key}, callback=whitelist_cb})
+        rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+                                   cmd='SISMEMBER', args={settings.blacklist_users_key, user_key}, callback=whitelist_cb})
+    end)
 end)
 
 rspamd_config:register_symbol('WHITELIST_WORD', 1.0, function(task)
     local user_id = tostring(task:get_header('X-Telegram-User', true) or "")
+    local chat_id = tostring(task:get_header('X-Telegram-Chat', true) or "")
     if user_id == "" then return false end
     local msg = tostring(task:get_rawbody()) or ""
     local words = break_to_words_util(msg)
     local count = 0
-    local function if_member_cb(err, data)
-        if err or not data then return end
-        if data then
-            count = count + 1
+    if_feature_enabled(task, chat_id, 'whitelist', function()
+        local function if_member_cb(err, data)
+            if err or not data then return end
+            if data then
+                count = count + 1
+            end
         end
-    end
-    for word in words do
-        rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
-                                   cmd='SISMEMBER', args={settings.whitelist_words_key, word}, callback=if_member_cb})
-    end
-    task:insert_result('WHITELIST_WORD', count)
+        for word in words do
+            rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+                cmd='SISMEMBER', args={settings.whitelist_words_key, word}, callback=if_member_cb})
+        end
+        task:insert_result('WHITELIST_WORD', count)
+    end)
 end)
 
 rspamd_config:register_symbol('BLACKLIST_WORD', 1.0, function(task)
     local user_id = tostring(task:get_header('X-Telegram-User', true) or "")
+    local chat_id = tostring(task:get_header('X-Telegram-Chat', true) or "")
     if user_id == "" then return false end
     local msg = tostring(task:get_rawbody()) or ""
     local words = break_to_words_util(msg)
     local count = 0
-    local function if_member_cb(err, data)
-        if err or not data then return end
-        if data then
-            count = count + 1
+    if_feature_enabled(task, chat_id, 'blacklist', function()
+        local function if_member_cb(err, data)
+            if err or not data then return end
+            if data then
+                count = count + 1
+            end
         end
-    end
-    for word in words do
-        rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
-                                   cmd='SISMEMBER', args={settings.blacklist_words_key, word}, callback=if_member_cb})
-    end
-    task:insert_result('BLACKLIST_WORD', count)
+        for word in words do
+            rspamd_redis.make_request({task=task, host="127.0.0.1:6379",
+                cmd='SISMEMBER', args={settings.blacklist_words_key, word}, callback=if_member_cb})
+        end
+        task:insert_result('BLACKLIST_WORD', count)
+    end)
 end)
 
 function break_to_words_util(str)

--- a/src/admin_handlers/admin.rs
+++ b/src/admin_handlers/admin.rs
@@ -7,7 +7,7 @@ use teloxide::{prelude::*, types::InlineKeyboardButton, types::InlineKeyboardMar
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
-use crate::config::{field, key, suffix};
+use crate::config::{field, key, suffix, ENABLED_FEATURES_KEY};
 
 use anyhow::Result;
 use regex::Regex;
@@ -391,7 +391,10 @@ pub async fn handle_admin_command(bot: Bot, msg: Message, cmd: AdminCommand) -> 
                     bot.send_message(chat_id, format!("Failed to write: {e}")).await?;
                     return Ok(());
                 }
-                
+
+                // Register the new symbol as a feature enabled by default
+                let _: redis::RedisResult<()> = redis_conn.sadd(ENABLED_FEATURES_KEY, symbol);
+
                 bot.send_message(chat_id, format!(
                     "Added regex pattern: '{}' with symbol '{}' and score {}.\nPlease reload Rspamd to apply the rule.",
                     regex_pattern, symbol, score

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,9 +80,13 @@ pub mod symbol {
     pub const BLACKLIST_WORD: &str = "BLACKLIST_WORD";
 }
 
-pub const AVAILABLE_FEATURES: &[&str] = &[
+/// Features that are enabled for every chat by default.
+pub const DEFAULT_FEATURES: &[&str] = &[
     "flood",
     "repeat",
     "whitelist",
     "blacklist",
 ];
+
+/// Redis key storing the global set of features enabled by default.
+pub const ENABLED_FEATURES_KEY: &str = "tg:enabled_features";


### PR DESCRIPTION
## Summary
- introduce `DEFAULT_FEATURES` and `ENABLED_FEATURES_KEY` in config
- register default features in Redis when dispatcher starts
- store default features for new chats
- manage feature enable/disable using global set and chat overrides
- add redis checks in lua scripts so symbols run only when feature enabled
- automatically register regex symbols as enabled features

## Testing
- `cargo test` *(fails: Expected TG_REPEAT symbol)*


------
https://chatgpt.com/codex/tasks/task_e_684eecea807c8323b52a017dd6a4fd5e